### PR TITLE
New _find_starts_of_groups()

### DIFF
--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -517,7 +517,7 @@ _find_starts_of_groups(ds, cols::UnitRange, ::Val{T}; mapformats = true) where T
 
 function _find_starts_of_groups!(x, f, inbits)
     Threads.@threads for j in 2:length(inbits)
-        @inbounds inbits[j] = intbis[j]==1 ? 1 : !isequal(f(x[j]), f(x[j-1]))
+        @inbounds inbits[j] = inbis[j]==1 ? 1 : !isequal(f(x[j]), f(x[j-1]))
     end
 end
 function _find_starts_of_groups!(x, f, inbits, starts, ngroups)

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -518,13 +518,13 @@ _find_starts_of_groups(ds, cols::UnitRange, ::Val{T}; mapformats = true) where T
 
 function _find_starts_of_groups!(x, perm, f, inbits)
     Threads.@threads for j in 2:length(inbits)
-        @inbounds inbits[perm[j]] = inbits[perm[j]]==true ? true : !isequal(f(x[perm[j]]), f(x[perm[j-1]]))
+        @inbounds inbits[j] = inbits[j]==true ? true : !isequal(f(x[perm[j]]), f(x[perm[j-1]]))
     end
 end
 function _find_starts_of_groups!(x, perm, f, inbits, starts, ngroups)
 	Threads.@threads for j in 1:ngroups
 		i = starts[j]
-		@inbounds inbits[perm[i]] = inbits[perm[i]]==1 ? 1 : !isequal(f(x[perm[i]]), f(x[perm[i-1]]))
+		@inbounds inbits[i] = inbits[i]==1 ? 1 : !isequal(f(x[perm[i]]), f(x[perm[i-1]]))
 	end
 end
 

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -481,9 +481,9 @@ end
 # ds assumes is grouped based on cols and groups are gathered togther
 function _find_starts_of_groups(ds, cols::Vector, ::Val{T}; mapformats = true) where T
     colsidx = index(ds)[cols]
-    sortedidx = _groupcols(ds)
-	starts = _group_starts(ds)
-	ngroups = _ngroups(ds)
+    #sortedidx = _sortedcols(ds)
+	#starts = _group_starts(ds)
+	#ngroups = _ngroups(ds)
 
     ranges = Vector{T}(undef, nrow(ds))
     inbits = zeros(Bool, nrow(ds))
@@ -496,8 +496,8 @@ function _find_starts_of_groups(ds, cols::Vector, ::Val{T}; mapformats = true) w
         else
             _f = identity
         end
-        if length(colsidx) <= length(sortedidx) && colsidx == view(sortedidx, 1:length(colsidx))
-		    _find_starts_of_groups!(_columns(ds)[colsidx[j]], _f , inbits, starts, ngroups)
+        if !(typeof(ds) <: SubDataset) && length(colsidx) <= length(_sortedcols(ds)) && colsidx == view(_sortedcols(ds), 1:length(colsidx))
+		    _find_starts_of_groups!(_columns(ds)[colsidx[j]], _f , inbits, _group_starts(ds), _ngroups(ds))
         else
             _find_starts_of_groups!(_columns(ds)[colsidx[j]], _f , inbits)
         end

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -481,7 +481,7 @@ end
 # ds assumes is grouped based on cols and groups are gathered togther
 function _find_starts_of_groups(ds, cols::Vector, ::Val{T}; mapformats = true) where T
     colsidx = index(ds)[cols]
-    sortedidx = _sortedcols(ds)
+    sortedidx = _groupcols(ds)
 	starts = _group_starts(ds)
 	ngroups = _ngroups(ds)
 

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -517,7 +517,7 @@ _find_starts_of_groups(ds, cols::UnitRange, ::Val{T}; mapformats = true) where T
 
 function _find_starts_of_groups!(x, f, inbits)
     Threads.@threads for j in 2:length(inbits)
-        @inbounds inbits[j] = inbis[j]==1 ? 1 : !isequal(f(x[j]), f(x[j-1]))
+        @inbounds inbits[j] = inbits[j]==1 ? 1 : !isequal(f(x[j]), f(x[j-1]))
     end
 end
 function _find_starts_of_groups!(x, f, inbits, starts, ngroups)

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -522,7 +522,7 @@ function _find_starts_of_groups!(x, perm, f, inbits)
     end
 end
 function _find_starts_of_groups!(x, perm, f, inbits, starts, ngroups)
-	Threads.@threads for i in 1:ngroups
+	Threads.@threads for j in 1:ngroups
 		i = starts[j]
 		@inbounds inbits[perm[i]] = inbits[perm[i]]==1 ? 1 : !isequal(f(x[perm[i]]), f(x[perm[i-1]]))
 	end

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -490,14 +490,14 @@ function _find_starts_of_groups(ds, cols::Vector, ::Val{T}; mapformats = true) w
     inbits = zeros(Bool, nrow(ds))
     inbits[1] = true
     last_valid_index = 1
-	
+	perm = typeof(ds) == GroupBy ? _get_perms(ds) : 1:nrow(ds)
+
     for j in 1:length(colsidx)
         if mapformats
             _f = getformat(ds, colsidx[j])
         else
             _f = identity
         end
-        perm = typeof(ds) == GroupBy ? _get_perms(ds) : 1:nrow(ds)
         if !(typeof(ds) <: SubDataset) && length(colsidx) <= length(_sortedcols(ds)) && colsidx == view(_sortedcols(ds), 1:length(colsidx)) && mapformats == _get_fmt(ds)
 		    _find_starts_of_groups!(_columns(ds)[colsidx[j]], perm, _f , inbits, _group_starts(ds), _ngroups(ds))
         else

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -481,7 +481,7 @@ end
 # ds assumes is grouped based on cols and groups are gathered togther
 function _find_starts_of_groups(ds, cols::Vector, ::Val{T}; mapformats = true) where T
     colsidx = index(ds)[cols]
-    perm = _get_perms(ds)
+    #perm = _get_perms(ds)
     #sortedidx = _sortedcols(ds)
 	#starts = _group_starts(ds)
 	#ngroups = _ngroups(ds)
@@ -497,6 +497,7 @@ function _find_starts_of_groups(ds, cols::Vector, ::Val{T}; mapformats = true) w
         else
             _f = identity
         end
+        perm = typeof(ds) == GroupBy ? _get_perms(ds) : 1:nrow(ds)
         if !(typeof(ds) <: SubDataset) && length(colsidx) <= length(_sortedcols(ds)) && colsidx == view(_sortedcols(ds), 1:length(colsidx)) && mapformats == _get_fmt(ds)
 		    _find_starts_of_groups!(_columns(ds)[colsidx[j]], perm, _f , inbits, _group_starts(ds), _ngroups(ds))
         else

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -491,7 +491,7 @@ function _find_starts_of_groups(ds, cols::Vector, ::Val{T}; mapformats = true) w
     last_valid_index = 1
 	
     for j in 1:length(colsidx)
-        if mapformats && typeof(ds) <: AbstractDataset
+        if mapformats
             _f = getformat(ds, colsidx[j])
         else
             _f = identity

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -142,3 +142,46 @@ using InMemoryDatasets, PooledArrays, Random, Test, CategoricalArrays
     @test sortperm(dsl, :)==sortperm(dsr, :)
     @test sortperm(dsl, :, rev=true)==sortperm(dsr, :, rev=true)
 end
+
+@testset "_find_starts_of_groups" begin
+    # Suppose there will be at least one row and one column.
+    ds = Dataset(x1 = [1])
+    colsidx = [1]
+    T = nrow(ds) < typemax(Int32) ? Val(Int32) : Val(Int64)
+    ranges = [1]
+    last_valid_index = 1
+    r1, r2, r3 = _find_starts_of_groups(ds, colsidx, T)
+    @test r1 == colsidx
+    @test r3 == last_valid_index
+    @test r2 == ranges[1:r3]
+
+    ds = Dataset(x1 = [1,1,1,3,3,1,1])
+    colsidx = [1]
+    T = nrow(ds) < typemax(Int32) ? Val(Int32) : Val(Int64)
+    ranges = [1, 4, 6]
+    last_valid_index = 3
+    r1, r2, r3 = _find_starts_of_groups(ds, colsidx, T)
+    @test r1 == colsidx
+    @test r3 == last_valid_index
+    @test r2[1:r3] == ranges
+
+    ds = Dataset(x1 = [1], x2 = [1], x3 = [2], x4 = [4])
+    colsidx = 1:3
+    T = nrow(ds) < typemax(Int32) ? Val(Int32) : Val(Int64)
+    ranges = [1]
+    last_valid_index = 1
+    r1, r2, r3 = _find_starts_of_groups(ds, colsidx, T)
+    @test r1 == colsidx
+    @test r3 == last_valid_index
+    @test r2[1:r3] == ranges
+
+    ds = Dataset(x1 = [1, 1, 1, 1, 3, 3, 3], x2 = [1, 6, 5, 5, 5, 5, 2], x3 = [2, 2, 4, 4, 4, 4, 1], x4 = [4, 1, 1, 4, 4, 4, 1])
+    colsidx = 1:3
+    T = nrow(ds) < typemax(Int32) ? Val(Int32) : Val(Int64)
+    ranges = [1, 2, 3, 5, 7]
+    last_valid_index = 5
+    r1, r2, r3 = _find_starts_of_groups(ds, colsidx, T)
+    @test r1 == colsidx
+    @test r3 == last_valid_index
+    @test r2[1:r3] == ranges
+end

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -176,7 +176,12 @@ end
     @test r2[1:r3] == ranges
 
     # Not only for Dataset, but also GroupBy.
-    gb = groupby(ds, :)
+    ds = Dataset(x1 = [1, 1, 1], x2 = [1, 2, 1])
+    gb = groupby(ds, 2)
+    colsidx = [2]
+    T = nrow(ds) < typemax(Int32) ? Val(Int32) : Val(Int64)
+    ranges = [1, 3]
+    last_valid_index = 2
     r1, r2, r3 = IMD._find_starts_of_groups(gb, colsidx, T)
     @test r1 == colsidx
     @test r3 == last_valid_index
@@ -198,6 +203,48 @@ end
     ranges = [1, 2, 3, 7]
     last_valid_index = 4
     r1, r2, r3 = IMD._find_starts_of_groups(ds, colsidx, T) # Use formatted values.
+    @test r1 == colsidx
+    @test r3 == last_valid_index
+    @test r2[1:r3] == ranges
+
+    # Consider whether ds is sorted using formatted values.
+    # If ds is sorted using formatted values.
+    format2(x) = abs(2.5 - x)
+    ds = Dataset(x1 = [1, 1, 1, 1, 3, 3, 3], x2 = [1, 6, 5, 5, 5, 5, 2], x3 = [2, 1, 4, 4, 4, 4, 1], x4 = [4, 1, 1, 4, 4, 4, 1])
+    setformat!(ds, 3:4 => format2)
+    dss = sort(ds, 3, mapformats = true) # Use formatted values for sorting.
+    colsidx = [1, 3, 4]
+    T = nrow(dss) < typemax(Int32) ? Val(Int32) : Val(Int64)
+    ranges = [1, 2, 3, 4, 5, 7]
+    last_valid_index = 6
+    r1, r2, r3 = IMD._find_starts_of_groups(dss, colsidx, T, mapformats = false) # Do not use formatted values.
+    @test r1 == colsidx
+    @test r3 == last_valid_index
+    @test r2[1:r3] == ranges
+
+    ranges = [1, 2, 5]
+    last_valid_index = 3
+    r1, r2, r3 = IMD._find_starts_of_groups(dss, colsidx, T) # Use formatted values.
+    @test r1 == colsidx
+    @test r3 == last_valid_index
+    @test r2[1:r3] == ranges
+
+    # If ds is sorted using unformatted values.
+    ds = Dataset(x1 = [1, 1, 1, 1, 3, 3, 3], x2 = [1, 6, 5, 5, 5, 5, 2], x3 = [2, 1, 4, 4, 4, 4, 1], x4 = [4, 1, 1, 4, 4, 4, 1])
+    setformat!(ds, 3:4 => format2)
+    dss = sort(ds, 3, mapformats = false) # Use unformatted values for sorting.
+    colsidx = [1, 3, 4]
+    T = nrow(dss) < typemax(Int32) ? Val(Int32) : Val(Int64)
+    ranges = [1, 2, 3, 4, 5, 6]
+    last_valid_index = 6
+    r1, r2, r3 = IMD._find_starts_of_groups(dss, colsidx, T, mapformats = false) # Do not use formatted values.
+    @test r1 == colsidx
+    @test r3 == last_valid_index
+    @test r2[1:r3] == ranges
+
+    ranges = [1, 2, 3, 4, 6]
+    last_valid_index = 5
+    r1, r2, r3 = IMD._find_starts_of_groups(dss, colsidx, T) # Use formatted values.
     @test r1 == colsidx
     @test r3 == last_valid_index
     @test r2[1:r3] == ranges

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -150,7 +150,7 @@ end
     T = nrow(ds) < typemax(Int32) ? Val(Int32) : Val(Int64)
     ranges = [1]
     last_valid_index = 1
-    r1, r2, r3 = _find_starts_of_groups(ds, colsidx, T)
+    r1, r2, r3 = IMD._find_starts_of_groups(ds, colsidx, T)
     @test r1 == colsidx
     @test r3 == last_valid_index
     @test r2 == ranges[1:r3]
@@ -160,7 +160,7 @@ end
     T = nrow(ds) < typemax(Int32) ? Val(Int32) : Val(Int64)
     ranges = [1, 4, 6]
     last_valid_index = 3
-    r1, r2, r3 = _find_starts_of_groups(ds, colsidx, T)
+    r1, r2, r3 = IMD._find_starts_of_groups(ds, colsidx, T)
     @test r1 == colsidx
     @test r3 == last_valid_index
     @test r2[1:r3] == ranges
@@ -170,7 +170,7 @@ end
     T = nrow(ds) < typemax(Int32) ? Val(Int32) : Val(Int64)
     ranges = [1]
     last_valid_index = 1
-    r1, r2, r3 = _find_starts_of_groups(ds, colsidx, T)
+    r1, r2, r3 = IMD._find_starts_of_groups(ds, colsidx, T)
     @test r1 == colsidx
     @test r3 == last_valid_index
     @test r2[1:r3] == ranges
@@ -180,7 +180,7 @@ end
     T = nrow(ds) < typemax(Int32) ? Val(Int32) : Val(Int64)
     ranges = [1, 2, 3, 5, 7]
     last_valid_index = 5
-    r1, r2, r3 = _find_starts_of_groups(ds, colsidx, T)
+    r1, r2, r3 = IMD._find_starts_of_groups(ds, colsidx, T)
     @test r1 == colsidx
     @test r3 == last_valid_index
     @test r2[1:r3] == ranges


### PR DESCRIPTION
Hi, would you like to have a look at this? The new function is nearly twice as fast as the old one.

I have carefully checked everything for `_find_starts_of_groups`. There is no change for input, output, and syntax. 

The only thing is that I have to remove two arguments in the in-place function `_find_starts_of_groups!` to get better performance.  In #17 you said that you do not want to change the syntax of this function, too. Maybe you plan to add something new in `_find_starts_of_groups!`  in the future?

I am just proposing the new code to get better performance. If it is not appropriate, you can just ignore the commits. 