### PR TITLE
LICENSE: copyright from DataFrames & Julia (fix #45)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,11 @@
 MIT License
 
 Copyright (c) 2021 sl-solution <github.sl.solution@icloud.com> and contributors
+Copyright (c) 2012-2022: Harlan Harris, EPRI (Tom Short's code), Chris DuBois,
+John Myles White, Milan Bouchet-Valat, Bogumił Kamiński and other DataFrames.jl
+contributors
+Copyright (c) 2009-2022: Jeff Bezanson, Stefan Karpinski, Viral B. Shah, and
+other Julia contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
As required by terms of the MIT license. Fixes #45.