### PR TITLE
Add HTML table display for GroupBy and GatherBy

### DIFF
--- a/src/sort/gatherby.jl
+++ b/src/sort/gatherby.jl
@@ -50,6 +50,9 @@ _names(ds::GatherBy) = _names(ds.parent)
 _columns(ds::GatherBy) = _columns(ds.parent)
 index(ds::GatherBy) = index(ds.parent)
 Base.parent(ds::GatherBy) = ds.parent
+Base.size(ds::GatherBy) = size(ds.parent)
+Base.size(ds::GatherBy, i::Integer) = size(ds.parent, i)
+getformat(ds::GatherBy, i) = getformat(ds.parent, i)
 
 
 Base.summary(gds::GatherBy) =

--- a/src/sort/groupby.jl
+++ b/src/sort/groupby.jl
@@ -29,6 +29,8 @@ _names(ds::GroupBy) = _names(ds.parent)
 _columns(ds::GroupBy) = _columns(ds.parent)
 index(ds::GroupBy) = index(ds.parent)
 Base.parent(ds::GroupBy) = ds.parent
+Base.size(ds::GroupBy) = size(ds.parent)
+Base.size(ds::GroupBy, i::Integer) = size(ds.parent, i)
 
 function groupby(ds::Dataset, cols::MultiColumnIndex; alg = HeapSortAlg(), rev = false, mapformats::Bool = true, stable = true, threads = true)
 	_check_consistency(ds)


### PR DESCRIPTION
Update the `_show()` and `getmaxwidths()` functions so now it could be used to display HTML table for `GroupBy` and `GatherBy`

Add `size()` function for `GroupBy`

Add `size()` and `getformat()` function for `GatherBy`