### PR TITLE
Fix compatibility with Julia 1.13+ memhash removal

### DIFF
--- a/src/characters/characters.jl
+++ b/src/characters/characters.jl
@@ -134,10 +134,12 @@ function write(io::IO, s::Characters{N}) where N
     return write(io, Ref(s))
 end
 
-function Base.hash(s::Characters{N}, h::UInt) where N
-    h += Base.memhash_seed
-    ref = Ref(s.data)
-    ccall(Base.memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32), ref, length(s), h % UInt32) + h
+if isdefined(Base, :memhash)
+    function Base.hash(s::Characters{N}, h::UInt) where N
+        h += Base.memhash_seed
+        ref = Ref(s.data)
+        ccall(Base.memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32), ref, length(s), h % UInt32) + h
+    end
 end
 
 


### PR DESCRIPTION
Remove hash method definition when Base.memhash is not available.
On Julia 1.13+, these AbstractString types will use the default
AbstractString hash implementation which is now efficient and
zero-copy based on codeunit/iterate.

For Julia <1.13, continue using the memhash-based implementation
for compatibility.

Related to JuliaLang/julia#59697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
